### PR TITLE
chore: retracted v1.0.0 as it was accidentally released

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract (
+    v1.0.0 // Published accidentally.
+)


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Added retraction for v1.0.0 in go.mod as it was accidentally published
- This ensures users will not be able to use the unintended v1.0.0 release



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Retract accidentally published v1.0.0 version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

<li>Added retract directive for v1.0.0 version that was accidentally <br>published<br>


</details>


  </td>
  <td><a href="https://github.com/MadsRC/historitor/pull/8/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information