### PR TITLE
OSV scanner needs read to GH Actions

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -26,6 +26,7 @@ permissions:
   security-events: write
   # Read commit contents
   contents: read
+  actions: read
 
 jobs:
   scan-scheduled:


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added required `actions: read` permission to the OSV scanner GitHub workflow to ensure proper access to GitHub Actions functionality
- This change complements existing permissions (security-events write and contents read) to enable full scanner operation



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>osv-scanner.yml</strong><dd><code>Add GitHub Actions read permission for OSV scanner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/osv-scanner.yml

<li>Added <code>actions: read</code> permission to allow OSV scanner to access GitHub <br>Actions<br>


</details>


  </td>
  <td><a href="https://github.com/MadsRC/historitor/pull/15/files#diff-cffe33bb0ffb2810cb2ba28b35e9fb9ebef98fd615b71ef50305846fa8ba0e00">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information